### PR TITLE
Update kube api resources

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -1,3 +1,6 @@
+#############################################
+### THERE WAS AN ERROR UPDATING THIS FILE ###
+#############################################
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -12,10 +15,10 @@ spec:
   template:
     metadata:
       annotations:
-{{- if and .Values.global.prometheus.enabled (not .Values.global.prometheus.serviceMonitor.enabled) }}
+#######{{- if and .Values.global.prometheus.enabled (not .Values.global.prometheus.serviceMonitor.enabled) }}
         prometheus.io/port: "{{ .Values.global.prometheus.port }}"
         prometheus.io/scrape: "true"
-{{- end }}
+#######{{- end }}
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
@@ -66,32 +69,32 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
-{{- if .Values.global.k8sServiceHost }}
+#######{{- if .Values.global.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST
           value: {{ .Values.global.k8sServiceHost | quote }}
-{{- end }}
-{{- if .Values.global.k8sServicePort }}
+#######{{- end }}
+#######{{- if .Values.global.k8sServicePort }}
         - name: KUBERNETES_SERVICE_PORT
           value: {{ .Values.global.k8sServicePort | quote }}
-{{- end }}
-{{- if contains "/" .Values.image }}
+#######{{- end }}
+#######{{- if contains "/" .Values.image }}
         image: "{{ .Values.image }}"
-{{- else }}
+#######{{- else }}
         image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
-{{- end }}
+#######{{- end }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
-{{- if .Values.global.cni.install }}
+#######{{- if .Values.global.cni.install }}
         lifecycle:
           postStart:
             exec:
               command:
               - "/cni-install.sh"
-              -{{- if .Values.global.debug.enabled }} "--enable-debug=true"{{- else }} "--enable-debug=false"{{- end }}
+              -######{{- if .Values.global.debug.enabled }} "--enable-debug=true"{{- else }} "--enable-debug=false"{{- end }}
           preStop:
             exec:
               command:
               - /cni-uninstall.sh
-{{- end }}
+#######{{- end }}
         livenessProbe:
           exec:
             command:
@@ -107,13 +110,13 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         name: cilium-agent
-{{- if .Values.global.prometheus.enabled }}
+#######{{- if .Values.global.prometheus.enabled }}
         ports:
         - containerPort: {{ .Values.global.prometheus.port }}
           hostPort: {{ .Values.global.prometheus.port }}
           name: prometheus
           protocol: TCP
-{{- end }}
+#######{{- end }}
         readinessProbe:
           exec:
             command:
@@ -132,91 +135,91 @@ spec:
             - SYS_MODULE
           privileged: true
         volumeMounts:
-{{- /* CRI-O already mounts the BPF filesystem */ -}}
-{{- if not (eq .Values.global.containerRuntime.integration "crio") }}
+#######{{- /* CRI-O already mounts the BPF filesystem */ -}}
+#######{{- if not (eq .Values.global.containerRuntime.integration "crio") }}
         - mountPath: /sys/fs/bpf
           name: bpf-maps
-{{- end }}
+#######{{- end }}
         - mountPath: /var/run/cilium
           name: cilium-run
         - mountPath: /host/opt/cni/bin
           name: cni-path
         - mountPath: {{ .Values.global.cni.hostConfDirMountPath }}
           name: etc-cni-netd
-{{- if .Values.global.etcd.enabled }}
+#######{{- if .Values.global.etcd.enabled }}
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path
           readOnly: true
-{{- if or .Values.global.etcd.ssl .Values.global.etcd.managed }}
+#######{{- if or .Values.global.etcd.ssl .Values.global.etcd.managed }}
         - mountPath: /var/lib/etcd-secrets
           name: etcd-secrets
           readOnly: true
-{{- end }}
-{{- end }}
+#######{{- end }}
+#######{{- end }}
         - mountPath: /var/lib/cilium/clustermesh
           name: clustermesh-secrets
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
           readOnly: true
-{{- if .Values.global.cni.configMap }}
+#######{{- if .Values.global.cni.configMap }}
         - mountPath: {{ .Values.global.cni.confFileMountPath }}
           name: cni-configuration
           readOnly: true
-{{- end }}
+#######{{- end }}
           # Needed to be able to load kernel modules
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
         - mountPath: /run/xtables.lock
           name: xtables-lock
-{{- if .Values.global.encryption.enabled }}
+#######{{- if .Values.global.encryption.enabled }}
         - mountPath: {{ .Values.global.encryption.mountPath }}
           name: cilium-ipsec-secrets
-{{- end }}
-{{- if .Values.global.kubeConfigPath }}
+#######{{- end }}
+#######{{- if .Values.global.kubeConfigPath }}
         - mountPath: {{ .Values.global.kubeConfigPath }}
           name: kube-config
           readOnly: true
-{{- end}}
-{{- if .Values.monitor.enabled }}
+#######{{- end}}
+#######{{- if .Values.monitor.enabled }}
       - name: cilium-monitor
         command: ["cilium"]
         args:
         - monitor
-{{- range $type := .Values.monitor.eventTypes }}
+#######{{- range $type := .Values.monitor.eventTypes }}
         - --type={{ $type }}
-{{- end }}
-{{- if contains "/" .Values.image }}
+#######{{- end }}
+#######{{- if contains "/" .Values.image }}
         image: "{{ .Values.image }}"
-{{- else }}
+#######{{- else }}
         image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
-{{- end }}
+#######{{- end }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run
-{{- end }}
-{{- if .Values.global.etcd.managed }}
+#######{{- end }}
+#######{{- if .Values.global.etcd.managed }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of
       # the etcd service
       dnsPolicy: ClusterFirstWithHostNet
-{{- end }}
+#######{{- end }}
       hostNetwork: true
       initContainers:
-{{- if and .Values.global.nodeinit.enabled (not (eq .Values.global.nodeinit.bootstrapFile "")) }}
+#######{{- if and .Values.global.nodeinit.enabled (not (eq .Values.global.nodeinit.bootstrapFile "")) }}
       - name: wait-for-node-init
         command: ['sh', '-c', 'until stat {{ .Values.global.nodeinit.bootstrapFile }} > /dev/null 2>&1; do echo "Waiting on node-init to run..."; sleep 1; done']
-{{- if contains "/" .Values.image }}
+#######{{- if contains "/" .Values.image }}
         image: "{{ .Values.image }}"
-{{- else }}
+#######{{- else }}
         image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
-{{- end }}
+#######{{- end }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         volumeMounts:
         - mountPath: {{ .Values.global.nodeinit.bootstrapFile }}
           name: cilium-bootstrap-file
-{{- end }}
+#######{{- end }}
       - command:
         - /init-container.sh
         env:
@@ -238,11 +241,11 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-{{- if contains "/" .Values.image }}
+#######{{- if contains "/" .Values.image }}
         image: "{{ .Values.image }}"
-{{- else }}
+#######{{- else }}
         image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
-{{- end }}
+#######{{- end }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         name: clean-cilium-state
         securityContext:
@@ -251,19 +254,19 @@ spec:
             - NET_ADMIN
           privileged: true
         volumeMounts:
-{{- /* CRI-O already mounts the BPF filesystem */ -}}
-{{- if not (eq .Values.global.containerRuntime.integration "crio") }}
+#######{{- /* CRI-O already mounts the BPF filesystem */ -}}
+#######{{- if not (eq .Values.global.containerRuntime.integration "crio") }}
         - mountPath: /sys/fs/bpf
           name: bpf-maps
-{{- /* Required for wait-bpf-mount to work */}}
+#######{{- /* Required for wait-bpf-mount to work */}}
           mountPropagation: HostToContainer
-{{- end }}
+#######{{- end }}
         - mountPath: /var/run/cilium
           name: cilium-run
       restartPolicy: Always
-{{- if and (eq .Release.Namespace "kube-system") (or (gt .Capabilities.KubeVersion.Minor "10") (gt .Capabilities.KubeVersion.Major "1"))}}
+#######{{- if and (eq .Release.Namespace "kube-system") (or (gt .Capabilities.KubeVersion.Minor "10") (gt .Capabilities.KubeVersion.Major "1"))}}
       priorityClassName: system-node-critical
-{{- end }}
+#######{{- end }}
       serviceAccount: cilium
       serviceAccountName: cilium
       terminationGracePeriodSeconds: 1
@@ -275,14 +278,14 @@ spec:
           path: {{ .Values.global.daemon.runPath }}
           type: DirectoryOrCreate
         name: cilium-run
-{{- /* CRI-O already mounts the BPF filesystem */ -}}
-{{- if not (eq .Values.global.containerRuntime.integration "crio") }}
+#######{{- /* CRI-O already mounts the BPF filesystem */ -}}
+#######{{- if not (eq .Values.global.containerRuntime.integration "crio") }}
         # To keep state between restarts / upgrades for bpf maps
       - hostPath:
           path: /sys/fs/bpf
           type: DirectoryOrCreate
         name: bpf-maps
-{{- end }}
+#######{{- end }}
       # To install cilium cni plugin in the host
       - hostPath:
           path:  {{ .Values.global.cni.binPath }}
@@ -302,19 +305,19 @@ spec:
           path: /run/xtables.lock
           type: FileOrCreate
         name: xtables-lock
-{{- if .Values.global.kubeConfigPath }}
+#######{{- if .Values.global.kubeConfigPath }}
       - hostPath:
           path: {{ .Values.global.kubeConfigPath }}
           type: FileOrCreate
         name: kube-config
-{{- end }}
-{{- if and .Values.global.nodeinit.enabled (not (eq .Values.global.nodeinit.bootstrapFile "")) }}
+#######{{- end }}
+#######{{- if and .Values.global.nodeinit.enabled (not (eq .Values.global.nodeinit.bootstrapFile "")) }}
       - hostPath:
           path: {{ .Values.global.nodeinit.bootstrapFile }}
           type: FileOrCreate
         name: cilium-bootstrap-file
-{{- end }}
-{{- if .Values.global.etcd.enabled }}
+#######{{- end }}
+#######{{- if .Values.global.etcd.enabled }}
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420
@@ -324,14 +327,14 @@ spec:
           name: cilium-config
         name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-{{- if or .Values.global.etcd.ssl .Values.global.etcd.managed }}
+#######{{- if or .Values.global.etcd.ssl .Values.global.etcd.managed }}
       - name: etcd-secrets
         secret:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-{{- end }}
-{{- end }}
+#######{{- end }}
+#######{{- end }}
         # To read the clustermesh configuration
       - name: clustermesh-secrets
         secret:
@@ -342,16 +345,16 @@ spec:
       - configMap:
           name: cilium-config
         name: cilium-config-path
-{{- if .Values.global.encryption.enabled }}
+#######{{- if .Values.global.encryption.enabled }}
       - name: cilium-ipsec-secrets
         secret:
           secretName: {{ .Values.global.encryption.secretName }}
-{{- end }}
-{{- if .Values.global.cni.configMap }}
+#######{{- end }}
+#######{{- if .Values.global.cni.configMap }}
       - name: cni-configuration
         configMap:
           name: {{ .Values.global.cni.configMap }}
-{{- end }}
+#######{{- end }}
   updateStrategy:
     rollingUpdate:
       maxUnavailable: {{ .Values.maxUnavailable }}

--- a/install/kubernetes/cilium/charts/managed-etcd/templates/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/charts/managed-etcd/templates/cilium-etcd-operator-deployment.yaml
@@ -1,3 +1,6 @@
+#############################################
+### THERE WAS AN ERROR UPDATING THIS FILE ###
+#############################################
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -52,13 +55,13 @@ spec:
           value: "revision"
         - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
           value: "25000"
-{{- if contains "/" .Values.image }}
+##{{- if contains "/" .Values.image }}
         image: "{{ .Values.image }}"
-{{- else if .Values.registry }}
+##{{- else if .Values.registry }}
         image: "{{ .Values.registry }}/{{ .Values.image }}:{{ .Values.tag }}"
-{{- else }}
+##{{- else }}
         image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.tag }}"
-{{- end }}
+##{{- end }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         name: cilium-etcd-operator
       dnsPolicy: ClusterFirst

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -1,3 +1,6 @@
+#############################################
+### THERE WAS AN ERROR UPDATING THIS FILE ###
+#############################################
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -20,10 +23,10 @@ spec:
   template:
     metadata:
       annotations:
-{{- if and .Values.global.prometheus.enabled (not .Values.global.prometheus.serviceMonitor.enabled) }}
+##{{- if and .Values.global.prometheus.enabled (not .Values.global.prometheus.serviceMonitor.enabled) }}
         prometheus.io/port: "6942"
         prometheus.io/scrape: "true"
-{{- end }}
+##{{- end }}
       labels:
         io.cilium/app: operator
         name: cilium-operator
@@ -32,12 +35,12 @@ spec:
       - args:
         - --debug=$(CILIUM_DEBUG)
         - --identity-allocation-mode=$(CILIUM_IDENTITY_ALLOCATION_MODE)
-{{- if .Values.global.prometheus.enabled }}
+##{{- if .Values.global.prometheus.enabled }}
         - --enable-metrics
-{{- end }}
-{{- if .Values.global.kubeConfigPath }}
+##{{- end }}
+##{{- if .Values.global.kubeConfigPath }}
         - --k8s-kubeconfig-path={{ .Values.global.kubeConfigPath }}
-{{- end }}
+##{{- end }}
         command:
         - cilium-operator
         env:
@@ -117,28 +120,28 @@ spec:
               key: identity-allocation-mode
               name: cilium-config
               optional: true
-{{- if .Values.global.k8sServiceHost }}
+##{{- if .Values.global.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST
           value: {{ .Values.global.k8sServiceHost | quote }}
-{{- end }}
-{{- if .Values.global.k8sServicePort }}
+##{{- end }}
+##{{- if .Values.global.k8sServicePort }}
         - name: KUBERNETES_SERVICE_PORT
           value: {{ .Values.global.k8sServicePort | quote }}
-{{- end }}
-{{- if contains "/" .Values.image }}
+##{{- end }}
+##{{- if contains "/" .Values.image }}
         image: "{{ .Values.image }}"
-{{- else }}
+##{{- else }}
         image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
-{{- end }}
+##{{- end }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         name: cilium-operator
-{{- if .Values.global.prometheus.enabled }}
+##{{- if .Values.global.prometheus.enabled }}
         ports:
         - containerPort: 6942
           hostPort: 6942
           name: prometheus
           protocol: TCP
-{{- end }}
+##{{- end }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -147,37 +150,37 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
-{{- if or .Values.global.etcd.enabled .Values.global.kubeConfigPath }}
+##{{- if or .Values.global.etcd.enabled .Values.global.kubeConfigPath }}
         volumeMounts:
-{{- end }}
-{{- if .Values.global.etcd.enabled }}
+##{{- end }}
+##{{- if .Values.global.etcd.enabled }}
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path
           readOnly: true
-{{- if or .Values.global.etcd.ssl .Values.global.etcd.managed }}
+##{{- if or .Values.global.etcd.ssl .Values.global.etcd.managed }}
         - mountPath: /var/lib/etcd-secrets
           name: etcd-secrets
           readOnly: true
-{{- end }}
-{{- end }}
-{{- if .Values.global.kubeConfigPath }}
+##{{- end }}
+##{{- end }}
+##{{- if .Values.global.kubeConfigPath }}
         - mountPath: {{ .Values.global.kubeConfigPath }}
           name: kube-config
           readOnly: true
-{{- end}}
+##{{- end}}
       hostNetwork: true
-{{- if .Values.global.etcd.managed }}
+##{{- if .Values.global.etcd.managed }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of
       # the etcd service
       dnsPolicy: ClusterFirstWithHostNet
-{{- end }}
+##{{- end }}
       restartPolicy: Always
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
-{{- if or .Values.global.etcd.enabled .Values.global.kubeConfigPath }}
+##{{- if or .Values.global.etcd.enabled .Values.global.kubeConfigPath }}
       volumes:
-{{- end }}
-{{- if .Values.global.etcd.enabled }}
+##{{- end }}
+##{{- if .Values.global.etcd.enabled }}
       # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420
@@ -186,18 +189,18 @@ spec:
             path: etcd.config
           name: cilium-config
         name: etcd-config-path
-{{- if or .Values.global.etcd.ssl .Values.global.etcd.managed }}
+##{{- if or .Values.global.etcd.ssl .Values.global.etcd.managed }}
         # To read the k8s etcd secrets in case the user might want to use TLS
       - name: etcd-secrets
         secret:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-{{- end }}
-{{- end }}
-{{- if .Values.global.kubeConfigPath }}
+##{{- end }}
+##{{- end }}
+##{{- if .Values.global.kubeConfigPath }}
       - hostPath:
           path: {{ .Values.global.kubeConfigPath }}
           type: FileOrCreate
         name: kube-config
-{{- end }}
+##{{- end }}

--- a/test/k8sT/manifests/http-clients.yaml
+++ b/test/k8sT/manifests/http-clients.yaml
@@ -1,20 +1,40 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
   name: http-client
 spec:
+  progressDeadlineSeconds: 600
+  replicas: 2
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: http-client
-  replicas: 2 # tells deployment to run 2 pods matching the template
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: http-client
         zgroup: http-client
     spec:
       containers:
-      - name: http-client
-        image: quay.io/isovalent/wrk2:latest
+      - image: quay.io/isovalent/wrk2:latest
+        imagePullPolicy: Always
+        name: http-client
         ports:
         - containerPort: 80
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status: {}

--- a/test/k8sT/manifests/http-deployment.yaml
+++ b/test/k8sT/manifests/http-deployment.yaml
@@ -1,20 +1,40 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
   name: http-server
 spec:
+  progressDeadlineSeconds: 600
+  replicas: 2
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: nginx
-  replicas: 2 # tells deployment to run 2 pods matching the template
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: nginx
         zgroup: http-server
     spec:
       containers:
-      - name: nginx
-        image: nginx:latest
+      - image: nginx:latest
+        imagePullPolicy: Always
+        name: nginx
         ports:
         - containerPort: 80
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status: {}

--- a/test/provision/manifest/1.12/coredns_deployment.yaml
+++ b/test/provision/manifest/1.12/coredns_deployment.yaml
@@ -73,57 +73,54 @@ data:
         reload
         loadbalance
     }
----
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: coredns
-  namespace: kube-system
+  creationTimestamp: null
   labels:
+    addonmanager.kubernetes.io/mode: Reconcile
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
-    kubernetes.io/name: "CoreDNS"
+    kubernetes.io/name: CoreDNS
+  name: coredns
+  namespace: kube-system
 spec:
-  # replicas: not specified here:
-  # 1. In order to make Addon Manager do not reconcile this replicas parameter.
-  # 2. Default is 1.
-  # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
+  progressDeadlineSeconds: 2147483647
+  replicas: 1
+  revisionHistoryLimit: 2147483647
   selector:
     matchLabels:
       k8s-app: kube-dns
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: docker/default
+      creationTimestamp: null
       labels:
         k8s-app: kube-dns
-      annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
-      serviceAccountName: coredns
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
-      - key: "CriticalAddonsOnly"
-        operator: "Exists"
       containers:
-      - name: coredns
+      - args:
+        - -conf
+        - /etc/coredns/Corefile
         image: k8s.gcr.io/coredns:1.2.2
         imagePullPolicy: IfNotPresent
-        resources:
-          limits:
-            memory: 170Mi
-          requests:
-            cpu: 100m
-            memory: 70Mi
-        args: [ "-conf", "/etc/coredns/Corefile" ]
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/coredns
-          readOnly: true
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: coredns
         ports:
         - containerPort: 53
           name: dns
@@ -134,15 +131,12 @@ spec:
         - containerPort: 9153
           name: metrics
           protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 60
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 5
+        resources:
+          limits:
+            memory: 170Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -150,15 +144,35 @@ spec:
             - NET_BIND_SERVICE
             drop:
             - all
+          procMount: Default
           readOnlyRootFilesystem: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: config-volume
+          readOnly: true
       dnsPolicy: Default
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: coredns
+      serviceAccountName: coredns
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - key: CriticalAddonsOnly
+        operator: Exists
       volumes:
-      - name: config-volume
-        configMap:
-          name: coredns
+      - configMap:
+          defaultMode: 420
           items:
           - key: Corefile
             path: Corefile
+          name: coredns
+        name: config-volume
+status: {}
 ---
 apiVersion: v1
 kind: Service

--- a/test/provision/manifest/1.13/coredns_deployment.yaml
+++ b/test/provision/manifest/1.13/coredns_deployment.yaml
@@ -79,90 +79,104 @@ data:
         reload
         loadbalance
     }
----
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: coredns
-  namespace: kube-system
+  creationTimestamp: null
   labels:
+    addonmanager.kubernetes.io/mode: Reconcile
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
-    kubernetes.io/name: "CoreDNS"
+    kubernetes.io/name: CoreDNS
+  name: coredns
+  namespace: kube-system
 spec:
-  # replicas: not specified here:
-  # 1. In order to make Addon Manager do not reconcile this replicas parameter.
-  # 2. Default is 1.
-  # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
+  progressDeadlineSeconds: 2147483647
+  replicas: 1
+  revisionHistoryLimit: 2147483647
   selector:
     matchLabels:
       k8s-app: kube-dns
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: docker/default
+      creationTimestamp: null
       labels:
         k8s-app: kube-dns
-      annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
-      serviceAccountName: coredns
-      tolerations:
-        - key: "CriticalAddonsOnly"
-          operator: "Exists"
       containers:
-        - name: coredns
-          image: k8s.gcr.io/coredns:1.2.6
-          imagePullPolicy: IfNotPresent
-          resources:
-            limits:
-              memory: 170Mi
-            requests:
-              cpu: 100m
-              memory: 70Mi
-          args: [ "-conf", "/etc/coredns/Corefile" ]
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/coredns
-              readOnly: true
-          ports:
-            - containerPort: 53
-              name: dns
-              protocol: UDP
-            - containerPort: 53
-              name: dns-tcp
-              protocol: TCP
-            - containerPort: 9153
-              name: metrics
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-              scheme: HTTP
-            initialDelaySeconds: 60
-            timeoutSeconds: 5
-            successThreshold: 1
-            failureThreshold: 5
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              add:
-                - NET_BIND_SERVICE
-              drop:
-                - all
-            readOnlyRootFilesystem: true
+      - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns:1.2.6
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: coredns
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9153
+          name: metrics
+          protocol: TCP
+        resources:
+          limits:
+            memory: 170Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - all
+          procMount: Default
+          readOnlyRootFilesystem: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: config-volume
+          readOnly: true
       dnsPolicy: Default
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: coredns
+      serviceAccountName: coredns
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
       volumes:
-        - name: config-volume
-          configMap:
-            name: coredns
-            items:
-              - key: Corefile
-                path: Corefile
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: Corefile
+            path: Corefile
+          name: coredns
+        name: config-volume
+status: {}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Hello there,

In preparation for upgrading to Kubernetes v1.16, (note: we have recently upgraded to v1.13), we have made changes to some of your kubernetes manifests.

The v1.16 release will stop serving a number of deprecated API versions in favor of newer and more stable API versions. For us, this means DaemonSet, Deployment, StatefulSet, and ReplicaSet all need to be updated to be using apps/v1. 

Any manifests referencing deprecated APIs (extensions/v1beta1, apps/v1beta1, or apps/v1beta2) will need to be updated before we roll out Kubernetes v1.16 in order to continue to work.

To lessen the work, we have gone through all the repositories and updated the resource APIs for you. We have pushed any changes to the `machinegun-<randomstring>` branch so feel free to make any changes and/or updates to this branch.

Note: If you are making changes, specifically to Deployments, make sure that you leave the Selector field under the Spec section as this is now mandatory.

During the conversion process, resources may have been updated with defaults and/or changed API fields. The defaults that you see were already in use but are now explicitly set.

Cosmetic changes may have also occurred, for example API fields may have moved around and comments may have been removed. Feel free to move API fields back to their original positions and re-add comments.

We appreciate your assistance in ensuring a smooth transition to Kubernetes v1.16.

If you have any questions, message in #cloud-infrastructure.

Thanks,

Cloud Team